### PR TITLE
Enlarge the job_summary_data field in rcc_job_log

### DIFF
--- a/schema/rcc_job_log.sql
+++ b/schema/rcc_job_log.sql
@@ -3,7 +3,7 @@ CREATE TABLE `rcc_job_log` (
   `log_date` datetime NOT NULL,
   `script_name` varchar(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `script_run_time` datetime NOT NULL,
-  `job_summary_data` text DEFAULT NULL,
+  `job_summary_data` mediumtext DEFAULT NULL,
   `job_duration` double not null,
   `level` enum('SUCCESS','DEBUG','ERROR') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),


### PR DESCRIPTION
I tripped on the TEXT data type being two small when I attempted to log setting two columns on 3200 rows of data.