### PR TITLE
Remove credentials for public image

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -12,9 +12,6 @@ jobs:
 
     container:
       image: ghcr.io/ctsit/rstudio-ci:4.1.0
-      credentials:
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.CR_PAT }}
 
     env:
       CI: "TRUE"


### PR DESCRIPTION
Removes credentials for public image to prevent the workflow from failing for fork PR's.