### PR TITLE
Move credential creation and scraping from main friday call to auxiliary setup file

### DIFF
--- a/docs/friday-call-demo-setup.Rmd
+++ b/docs/friday-call-demo-setup.Rmd
@@ -1,0 +1,115 @@
+---
+title: "REDCap Custodian Friday Call Demo Credentials Setup"
+author: "Philip Chase & Kyle Chesney"
+date: '2022-06-15'
+output:
+  pdf_document: default
+  html_document: default
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+```
+
+## Overview
+
+This is a demonstration of some features of the REDCap Custodian R package. 
+
+We will demonstrate how to:
+
+1. Fetch and store you API tokens in a database
+2. Get some data from a REDCap project
+3. Transform your data
+4. Write it to another project
+5. Review the logs of what the job
+
+Then we'll talk about how to automate that whole process.
+
+## Prequisites
+
+If you want to do this yourself, we recommend you do these things to setup your development and testing environment:
+
+1. Install R, Rstudio, and the tidyverse packages
+2. Install redcapcustodian from github
+3. Clone the [redcap-docker-compose](https://github.com/123andy/redcap-docker-compose/) git repo
+4. Create a local REDCap with redcap-docker-compose
+5. Create an new project in Rstudio.  Note this is an _R_ project, not a _REDCap_ project,
+6. Copy [local.env.txt](./local.env.txt) to .env in the root of your new project folder.
+
+You also need some REDCap projects to play with. If you have your own, that's great. for our demo, we need two REDCap projects to exist. Please make those projects with these XML files: [main](./main.xml) [biospecimen](./biospecimen.xml).
+
+Name the project from `main.xml`: "Demo Main"
+Name the project from `biospecimen.xml`: "Demo Biospecimen"
+
+To talk to those projects from code, they'll need API tokens. Add those to the main and biospecimen projects. Do the same for any other project you want to play with. 
+
+With those changes in place, you can start developing scripts that use REDCap custodian.
+
+## Premise
+
+You have a big important project with many rows of data and many more rows coming in every week, a researcher asks you to build them a biorepository project for the biospecimens collected for this protocol. We do not want anyone to transcribe existing data, so we will _automatically_ copy it for them every day. No transcription, no typos, no overtime.
+
+## Fetch API Tokens
+
+First, load some R packages:
+
+```{r packages}
+library(redcapcustodian)
+library(DBI)
+library(tidyverse)
+library(dotenv)
+library(lubridate)
+```
+
+
+Then, make a database to hold the credentials:
+
+```{r make_credentials_db}
+
+# fetching all extant API tokens and adding them to storage #################
+
+dir.create("credentials")
+
+# creates file if one does not exist
+file_conn <- DBI::dbConnect(RSQLite::SQLite(), here::here("credentials/credentials.db"))
+
+# SQLite friendly schema
+credentials_sql <- "CREATE TABLE IF NOT EXISTS `credentials` (
+  `redcap_uri` TEXT NOT NULL,
+  `server_short_name` varchar(128) NOT NULL,
+  `username` varchar(191) NOT NULL,
+  `project_id` int(10) NOT NULL,
+  `project_display_name` TEXT NOT NULL,
+  `project_short_name` varchar(128) DEFAULT NULL,
+  `token` varchar(64) NOT NULL,
+  `comment` varchar(256) DEFAULT NULL
+);
+"
+
+dbExecute(file_conn, credentials_sql)
+```
+
+Now, fetch all of your API tokens:
+
+```{r get_api_tokens}
+# fetching all extant API tokens and adding them to storage #################
+load_dot_env(here::here("local.env.txt"))
+
+my_username <- "admin"
+source_conn <- connect_to_redcap_db()
+scraped_credentials <- scrape_user_api_tokens(source_conn, my_username)
+
+# alter credentials to match local schema
+source_credentials_upload <- scraped_credentials %>%
+  mutate(
+    redcap_uri = Sys.getenv("URI"),
+    server_short_name = tolower(Sys.getenv("INSTANCE"))
+  ) %>%
+  # remove duplicates
+  anti_join(
+    tbl(file_conn, "credentials") %>%
+      collect()
+  )
+
+dbAppendTable(file_conn, "credentials", source_credentials_upload)
+```

--- a/docs/friday-call-demo-setup.Rmd
+++ b/docs/friday-call-demo-setup.Rmd
@@ -13,17 +13,15 @@ knitr::opts_chunk$set(echo = TRUE)
 
 ## Overview
 
-This is a demonstration of some features of the REDCap Custodian R package. 
+These are the setup instructions for a demonstration of some features of the REDCap Custodian R package. 
 
-We will demonstrate how to:
+In these setup steps, we will demonstrate how to:
 
-1. Fetch and store you API tokens in a database
-2. Get some data from a REDCap project
-3. Transform your data
-4. Write it to another project
-5. Review the logs of what the job
+1. Create a local credentials database
+1. Fetch and store your API tokens in the credentials database
+3. Create an load some fake data into the REDCap projects we want to test with.
 
-Then we'll talk about how to automate that whole process.
+All of this is a prelude to a demonstration of moving data between REDCap projects described in `friday-call-demo.Rmd`.
 
 ## Prequisites
 
@@ -43,13 +41,10 @@ Name the project from `biospecimen.xml`: "Demo Biospecimen"
 
 To talk to those projects from code, they'll need API tokens. Add those to the main and biospecimen projects. Do the same for any other project you want to play with. 
 
-With those changes in place, you can start developing scripts that use REDCap custodian.
+With those changes in place, you can start developing scripts that use REDCap Custodian.
 
-## Premise
 
-You have a big important project with many rows of data and many more rows coming in every week, a researcher asks you to build them a biorepository project for the biospecimens collected for this protocol. We do not want anyone to transcribe existing data, so we will _automatically_ copy it for them every day. No transcription, no typos, no overtime.
-
-## Fetch API Tokens
+## Fetch and store API Tokens
 
 First, load some R packages:
 
@@ -68,7 +63,7 @@ Then, make a database to hold the credentials:
 
 # fetching all extant API tokens and adding them to storage #################
 
-dir.create("credentials")
+dir.create(here::here("credentials"))
 
 # creates file if one does not exist
 file_conn <- DBI::dbConnect(RSQLite::SQLite(), here::here("credentials/credentials.db"))
@@ -89,7 +84,7 @@ credentials_sql <- "CREATE TABLE IF NOT EXISTS `credentials` (
 dbExecute(file_conn, credentials_sql)
 ```
 
-Now, fetch all of your API tokens:
+Now, fetch all of your API tokens and write them into your local credentials DB.
 
 ```{r get_api_tokens}
 # fetching all extant API tokens and adding them to storage #################
@@ -112,4 +107,89 @@ source_credentials_upload <- scraped_credentials %>%
   )
 
 dbAppendTable(file_conn, "credentials", source_credentials_upload)
+```
+
+## Make test data and write it to your test projects
+
+We will generate some records for your main project for you to port over to the Biospecimen project. First, access the credential database to get your credentials to the REDCap project you want to read from.
+
+```{r read_source_credentials_from_db}
+source_credentials <- tbl(file_conn, "credentials") %>%
+  filter(username == my_username) %>%
+  collect() %>%
+  filter(str_detect(project_display_name, "Demo Main")) %>%
+  unnest()
+```
+
+We use Will Beasley's REDCapR library to interact with REDCap via its API. REDCapR allows you to specify the forms, fields, event names, and time frames of interest. It even allows REDCap filtering.
+
+It isn't necessary to understand most of the following block as you typically won't be populating a project with random data.
+
+```{r create data}
+record_count_to_create <- 50
+collection_events <- 5
+tubes_per_collection <- 30
+
+record_columns <- c(
+  "record_id",
+  "redcap_event_name",
+  "sample_collected_date",
+  "tmp_event_id",
+  paste0("tube_id", 1:tubes_per_collection),
+  paste0("tube_specimen_type", 1:tubes_per_collection),
+  paste0("tube_volume", 1:tubes_per_collection)
+  )
+
+# create empty dataframe and set column names
+simulated_data <- data.frame(
+  matrix(ncol = length(record_columns), nrow = 0)
+) %>%
+  mutate(across(everything(), as.character))
+colnames(simulated_data) <- record_columns
+
+# create base entries for each event
+# NOTE: may be a bit slow as for-loops are not generally used in R
+for (record_id in 1:record_count_to_create) {
+  for (event_id in 1:collection_events) {
+    simulated_data <- simulated_data %>%
+      add_row(
+        record_id = as.character(record_id),
+        redcap_event_name = paste0("event_", event_id, "_arm_1"),
+        tmp_event_id = as.character(event_id), # used to generate tube IDs later
+        sample_collected_date = sample(
+          seq(ymd("2020-03-01"), ymd("2022-06-01"), by = "day"), size = 1, replace = T
+        ) %>% as.character()
+      )
+  }
+}
+
+# group to ensure simulated data is consistent with a single collection event
+simulated_data <- simulated_data %>%
+  group_by(record_id, redcap_event_name)
+
+# simulate individual samples
+for (tube in 1:tubes_per_collection) {
+  simulated_data <- simulated_data %>%
+    mutate(
+      "tube_id{tube}" := paste0(
+        record_id, "-",
+        str_pad(tmp_event_id, width = 2, side = "left", pad = "0"), "-",
+        str_pad(tube, width = 2, side = "left", pad = "0")
+      ),
+      "tube_specimen_type{tube}" := sample(1:4, size = 1),
+      "tube_volume{tube}" := sample(2:4, size = 1)
+    )
+}
+
+# remove temporary column used in simulation
+simulated_data <- simulated_data %>%
+  ungroup() %>%
+  select(-tmp_event_id)
+
+# upload data to REDCap
+REDCapR::redcap_write(
+  redcap_uri = source_credentials$redcap_uri,
+  token = source_credentials$token,
+  ds_to_write = simulated_data
+)
 ```

--- a/docs/friday-call-demo.Rmd
+++ b/docs/friday-call-demo.Rmd
@@ -33,11 +33,25 @@ Follow the steps and run the code provided in friday-call-demo-setup.Rmd.
 
 You have a big important project with many rows of data and many more rows coming in every week, a researcher asks you to build them a biorepository project for the biospecimens collected for this protocol. We do not want anyone to transcribe existing data, so we will _automatically_ copy it for them every day. No transcription, no typos, no overtime.
 
-## Create some data for your REDCap project
 
-We will generate some records for your main project for you to port over to the Biospecimen project. First, access the credential database to get your credentials to the REDCap project you want to read from.
+## Get some data from a REDCap project
+
+First, load some R packages:
+
+```{r packages}
+library(redcapcustodian)
+library(DBI)
+library(tidyverse)
+library(dotenv)
+library(lubridate)
+```
+
+
+Next, connect to the credential database. Then read your credentials to the REDCap project you want to read from.
 
 ```{r read_source_credentials_from_db}
+file_conn <- DBI::dbConnect(RSQLite::SQLite(), here::here("credentials/credentials.db"))
+
 source_credentials <- tbl(file_conn, "credentials") %>%
   filter(username == my_username) %>%
   collect() %>%
@@ -45,82 +59,7 @@ source_credentials <- tbl(file_conn, "credentials") %>%
   unnest()
 ```
 
-We use Will Beasley's REDCapR library to interact with REDCap via its API. REDCapR allows you to specify the forms, fields, event names, and time frames of interest. It even allows REDCap filtering.
-
-It isn't entirely necessary to understand most the following block as you typically won't be populating a project with random data.
-
-```{r create data}
-record_count_to_create <- 50
-collection_events <- 5
-tubes_per_collection <- 30
-
-record_columns <- c(
-  "record_id",
-  "redcap_event_name",
-  "sample_collected_date",
-  "tmp_event_id",
-  paste0("tube_id", 1:tubes_per_collection),
-  paste0("tube_specimen_type", 1:tubes_per_collection),
-  paste0("tube_volume", 1:tubes_per_collection)
-  )
-
-# create empty dataframe and set column names
-simulated_data <- data.frame(
-  matrix(ncol = length(record_columns), nrow = 0)
-) %>%
-  mutate(across(everything(), as.character))
-colnames(simulated_data) <- record_columns
-
-# create base entries for each event
-# NOTE: may be a bit slow as for-loops are not generally used in R
-for (record_id in 1:record_count_to_create) {
-  for (event_id in 1:collection_events) {
-    simulated_data <- simulated_data %>%
-      add_row(
-        record_id = as.character(record_id),
-        redcap_event_name = paste0("event_", event_id, "_arm_1"),
-        tmp_event_id = as.character(event_id), # used to generate tube IDs later
-        sample_collected_date = sample(
-          seq(ymd("2020-03-01"), ymd("2022-06-01"), by = "day"), size = 1, replace = T
-        ) %>% as.character()
-      )
-  }
-}
-
-# group to ensure simulated data is consistent with a single collection event
-simulated_data <- simulated_data %>%
-  group_by(record_id, redcap_event_name)
-
-# simulate individual samples
-for (tube in 1:tubes_per_collection) {
-  simulated_data <- simulated_data %>%
-    mutate(
-      "tube_id{tube}" := paste0(
-        record_id, "-",
-        str_pad(tmp_event_id, width = 2, side = "left", pad = "0"), "-",
-        str_pad(tube, width = 2, side = "left", pad = "0")
-      ),
-      "tube_specimen_type{tube}" := sample(1:4, size = 1),
-      "tube_volume{tube}" := sample(2:4, size = 1)
-    )
-}
-
-# remove temporary column used in simulation
-simulated_data <- simulated_data %>%
-  ungroup() %>%
-  select(-tmp_event_id)
-
-# upload data to REDCap
-REDCapR::redcap_write(
-  redcap_uri = source_credentials$redcap_uri,
-  token = source_credentials$token,
-  ds_to_write = simulated_data
-)
-```
-
-## Get some data from a REDCap project
-
-At this point it's time to read the portions of the project data that interest you.
+At this point, it's time to read the portions of the project data that interest you.
 
 For our task, we want to read identifiers for collected data so we can write them into the Biospecimen tracking project
 
@@ -183,8 +122,12 @@ old_target_project_data <- REDCapR::redcap_read(
   fields = target_fields_to_read
 )
 
-target_project_data <- new_target_project_data %>%
-  dplyr::anti_join(old_target_project_data$data)
+if (old_target_project_data$success) {
+  target_project_data <- new_target_project_data %>%
+    dplyr::anti_join(old_target_project_data$data)
+} else {
+  target_project_data <- new_target_project_data
+}
 
 # now write that small dataset
 REDCapR::redcap_write(

--- a/docs/friday-call-demo.Rmd
+++ b/docs/friday-call-demo.Rmd
@@ -44,6 +44,8 @@ library(DBI)
 library(tidyverse)
 library(dotenv)
 library(lubridate)
+
+init_etl("friday_call_demo")
 ```
 
 
@@ -130,11 +132,20 @@ if (old_target_project_data$success) {
 }
 
 # now write that small dataset
-REDCapR::redcap_write(
-  ds_to_write = slice_head(target_project_data, prop= 0.5),
+result <- REDCapR::redcap_write(
+  ds_to_write = slice_head(target_project_data, prop=0.5),
   redcap_uri = target_credentials$redcap_uri,
   token = target_credentials$token
 )
+
+# now log what we did
+if (result$success) {
+  log_job_success(jsonlite::toJSON(target_project_data))
+} else {
+  log_job_failure(jsonlite::toJSON(result))
+}
+
+
 ```
 
 ## Review the logs of what the job

--- a/docs/friday-call-demo.Rmd
+++ b/docs/friday-call-demo.Rmd
@@ -67,6 +67,9 @@ At this point, it's time to read the portions of the project data that interest 
 For our task, we want to read identifiers for collected data so we can write them into the Biospecimen tracking project
 
 ```{r read data}
+record_count_to_create <- 50
+collection_events <- 5
+tubes_per_collection <- 30
 
 fields_to_read <- c(
   "record_id",

--- a/docs/friday-call-demo.Rmd
+++ b/docs/friday-call-demo.Rmd
@@ -157,6 +157,6 @@ if (result$success) {
 When doing automated jobs, it's important to have a record of what happened. REDCap Custodian writes logs so you can review its actions later.
 
 ```{r read_logs}
-
-
+log_con <- get_package_scope_var("log_con")
+tbl(log_con, "rcc_job_log")
 ```

--- a/docs/friday-call-demo.Rmd
+++ b/docs/friday-call-demo.Rmd
@@ -53,6 +53,7 @@ Next, connect to the credential database. Then read your credentials to the REDC
 
 ```{r read_source_credentials_from_db}
 file_conn <- DBI::dbConnect(RSQLite::SQLite(), here::here("credentials/credentials.db"))
+my_username <- "admin"
 
 source_credentials <- tbl(file_conn, "credentials") %>%
   filter(username == my_username) %>%

--- a/docs/friday-call-demo.Rmd
+++ b/docs/friday-call-demo.Rmd
@@ -2,7 +2,9 @@
 title: "REDCap Custodian Friday Call Demo"
 author: "Philip Chase & Kyle Chesney"
 date: '2022-06-15'
-output: html_document
+output:
+  pdf_document: default
+  html_document: default
 ---
 
 ```{r setup, include=FALSE}
@@ -15,102 +17,21 @@ This is a demonstration of some features of the REDCap Custodian R package.
 
 We will demonstrate how to:
 
-2. Fetch and store you API tokens in a database
-3. Get some data from a REDCap project
-4. Transform your data
-5. Write it to another project
-6. Review the logs of what the job
+1. Fetch and store you API tokens in a database
+2. Get some data from a REDCap project
+3. Transform your data
+4. Write it to another project
+5. Review the logs of what the job
 
 Then we'll talk about how to automate that whole process.
 
 ## Prequisites
 
-If you want to do this yourself, we recommend you do these things to setup your development and testing environment:
-
-1. Install R, Rstudio, and the tidyverse packages
-2. Install redcapcustodian from github
-3. Clone the [redcap-docker-compose](https://github.com/123andy/redcap-docker-compose/) git repo
-4. Create a local REDCap with redcap-docker-compose
-5. Create an new project in Rstudio.  Note this is an _R_ project, not a _REDCap_ project,
-6. Copy [local.env.txt](./local.env.txt) to .env in the root of your new project folder.
-
-You also need some REDCap projects to play with. If you have your own, that's great. for our demo, we need two REDCap projects to exist. Please make those projects with these XML files: [main](./main.xml) [biospecimen](./biospecimen.xml).
-
-Name the project from `main.xml`: "Demo Main"
-Name the project from `biospecimen.xml`: "Demo Biospecimen"
-
-To talk to those projects from code, they'll need API tokens. Add those to the main and biospecimen projects. Do the same for any other project you want to play with. 
-
-With those changes in place, you can start developing scripts that use REDCap custodian.
+Follow the steps and run the code provided in friday-call-demo-setup.Rmd.
 
 ## Premise
 
 You have a big important project with many rows of data and many more rows coming in every week, a researcher asks you to build them a biorepository project for the biospecimens collected for this protocol. We do not want anyone to transcribe existing data, so we will _automatically_ copy it for them every day. No transcription, no typos, no overtime.
-
-## Fetch API Tokens
-
-First, load some R packages:
-
-```{r packages}
-library(redcapcustodian)
-library(DBI)
-library(tidyverse)
-library(dotenv)
-library(lubridate)
-```
-
-
-Then, make a database to hold the credentials:
-
-```{r make_credentials_db}
-
-# fetching all extant API tokens and adding them to storage #################
-
-dir.create("credentials")
-
-# creates file if one does not exist
-file_conn <- DBI::dbConnect(RSQLite::SQLite(), here::here("credentials/credentials.db"))
-
-# SQLite friendly schema
-credentials_sql <- "CREATE TABLE IF NOT EXISTS `credentials` (
-  `redcap_uri` TEXT NOT NULL,
-  `server_short_name` varchar(128) NOT NULL,
-  `username` varchar(191) NOT NULL,
-  `project_id` int(10) NOT NULL,
-  `project_display_name` TEXT NOT NULL,
-  `project_short_name` varchar(128) DEFAULT NULL,
-  `token` varchar(64) NOT NULL,
-  `comment` varchar(256) DEFAULT NULL
-);
-"
-
-dbExecute(file_conn, credentials_sql)
-```
-
-Now, fetch all of your API tokens:
-
-```{r get_api_tokens}
-# fetching all extant API tokens and adding them to storage #################
-load_dot_env(here::here("local.env.txt"))
-
-my_username <- "admin"
-source_conn <- connect_to_redcap_db()
-scraped_credentials <- scrape_user_api_tokens(source_conn, my_username)
-
-# alter credentials to match local schema
-source_credentials_upload <- scraped_credentials %>%
-  mutate(
-    redcap_uri = Sys.getenv("URI"),
-    server_short_name = tolower(Sys.getenv("INSTANCE"))
-  ) %>%
-  # remove duplicates
-  anti_join(
-    tbl(file_conn, "credentials") %>%
-      collect()
-  )
-
-dbAppendTable(file_conn, "credentials", source_credentials_upload)
-```
 
 ## Create some data for your REDCap project
 


### PR DESCRIPTION
Wondering if we should also move the data fabrication to the setup?