### PR TITLE
Add email_from and email_cc params to send_email function, default to env values

### DIFF
--- a/R/logging.R
+++ b/R/logging.R
@@ -568,7 +568,9 @@ write_info_log_entry <- function(conn, target_db_name, table_written = NULL, df,
 #'
 #' @param email_body The contents of the email
 #' @param email_subject The subject line of the email
-#' @param email_to The email addresses
+#' @param email_to The email addresses of the primary recipient(s), separate recipient addresses with spaces
+#' @param email_cc The email addresses of cc'd recipient(s), separate recipient addresses with spaces
+#' @param email_from The email addresses of the sender
 #' @return No returned value
 #' @examples
 #'
@@ -583,11 +585,17 @@ write_info_log_entry <- function(conn, target_db_name, table_written = NULL, df,
 #' }
 #' @importFrom sendmailR "sendmail"
 #' @export
-send_email <- function(email_body, email_subject = "", email_to = "") {
+send_email <- function(email_body, email_subject = "", email_to = "", email_cc = "", email_from = "") {
   # email credentials
   email_server <- list(smtpServer = Sys.getenv("SMTP_SERVER"))
-  email_from <- Sys.getenv("EMAIL_FROM")
-  email_cc <- unlist(strsplit(Sys.getenv("EMAIL_CC"), " "))
+  if (email_from == "") {
+    email_from <- Sys.getenv("EMAIL_FROM")
+  }
+  if (email_cc == "") {
+    email_cc <- unlist(strsplit(Sys.getenv("EMAIL_CC"), " "))
+  } else {
+    email_cc <- unlist(strsplit(email_to, " "))
+  }
   if (email_subject == "") {
     email_subject <- paste(Sys.getenv("EMAIL_SUBJECT"), get_script_run_time())
   }

--- a/man/send_email.Rd
+++ b/man/send_email.Rd
@@ -4,14 +4,24 @@
 \alias{send_email}
 \title{A wrapper function that sends an email (via sendmailR) reporting the outcome of another function}
 \usage{
-send_email(email_body, email_subject = "", email_to = "")
+send_email(
+  email_body,
+  email_subject = "",
+  email_to = "",
+  email_cc = "",
+  email_from = ""
+)
 }
 \arguments{
 \item{email_body}{The contents of the email}
 
 \item{email_subject}{The subject line of the email}
 
-\item{email_to}{The email addresses}
+\item{email_to}{The email addresses of the primary recipient(s), separate recipient addresses with spaces}
+
+\item{email_cc}{The email addresses of cc'd recipient(s), separate recipient addresses with spaces}
+
+\item{email_from}{The email addresses of the sender}
 }
 \value{
 No returned value


### PR DESCRIPTION
I think this is a little more user friendly than `.env` overloading in `docker run`.

The PR for https://github.com/ctsit/rcc.billing/issues/61 will depend on this.