### PR TITLE
Modernize container and add dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM rocker/tidyverse:4.2.1
 WORKDIR /home/rocker
 
 RUN apt update -y && apt install -y libmariadb-dev libmariadbclient-dev
+RUN apt install -y --no-install-recommends libxt6
 
 # install necessary libraries
 RUN R -e "install.packages(c( \
@@ -16,7 +17,6 @@ RUN R -e "install.packages(c( \
   'dotenv', \
   'here', \
   'janitor', \
-  'mRpostman', \
   'rjson', \
   'sendmailR', \
   'sqldf', \
@@ -24,8 +24,6 @@ RUN R -e "install.packages(c( \
 ))"
 
 RUN R -e "devtools::install_github('allanvc/mRpostman')"
-
-RUN apt install -y --no-install-recommends libxt6
 
 # build and install this package
 ADD . /home/rocker/redcapcustodian

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,31 @@
-FROM rocker/tidyverse:4.1.0
+FROM rocker/tidyverse:4.2.1
 
 WORKDIR /home/rocker
 
 RUN apt update -y && apt install -y libmariadb-dev libmariadbclient-dev
 
 # install necessary libraries
-RUN R -e "install.packages(c('sendmailR', 'dotenv', 'RCurl', 'checkmate', 'janitor', 'sqldf', 'DBI', 'RMariaDB', 'digest','rjson', 'dbx'))"
-RUN R -e "install.packages(c('REDCapR', 'mRpostman', 'writexl', 'here'))"
+RUN R -e "install.packages(c( \
+  'DBI', \
+  'RCurl', \
+  'REDCapR', \
+  'RMariaDB', \
+  'checkmate', \
+  'dbx', \
+  'digest', \
+  'dotenv', \
+  'here', \
+  'janitor', \
+  'mRpostman', \
+  'rjson', \
+  'sendmailR', \
+  'sqldf', \
+  'writexl' \
+))"
+
+RUN R -e "devtools::install_github('allanvc/mRpostman')"
+
+RUN apt install -y --no-install-recommends libxt6
 
 # build and install this package
 ADD . /home/rocker/redcapcustodian


### PR DESCRIPTION
Address missing `mRpostman` and Debian package dependencies.

Container build is still failing with 

```
 > [ 8/21] RUN R CMD build redcapcustodian:                                                                                 
#12 1.396 * checking for file ‘redcapcustodian/DESCRIPTION’ ... OK                                                          
#12 1.500 * preparing ‘redcapcustodian’:                                                                                    
#12 1.502 * checking DESCRIPTION meta-information ... OK                                                                    
#12 1.991 * installing the package to build vignettes                                                                       
#12 12.11 * creating vignettes ... ERROR
#12 21.01 --- re-building ‘credential-scraping.Rmd’ using rmarkdown
#12 21.01 Killed
#12 21.01 Warning in system(paste(shQuote(path), "--version"), intern = TRUE) :
#12 21.01   running command ''/usr/local/bin/pandoc' --version' had status 137
#12 21.01 Error: processing vignette 'credential-scraping.Rmd' failed with diagnostics:
#12 21.01 subscript out of bounds
#12 21.01 --- failed re-building ‘credential-scraping.Rmd’
#12 21.01 
#12 21.01 --- re-building ‘expire_user_project_rights.Rmd’ using rmarkdown
#12 21.01 Killed
#12 21.01 Warning in system(paste(shQuote(path), "--version"), intern = TRUE) :
#12 21.01   running command ''/usr/local/bin/pandoc' --version' had status 137
#12 21.01 Error: processing vignette 'expire_user_project_rights.Rmd' failed with diagnostics:
#12 21.01 subscript out of bounds
#12 21.01 --- failed re-building ‘expire_user_project_rights.Rmd’
#12 21.01 
#12 21.01 SUMMARY: processing the following files failed:
#12 21.01   ‘credential-scraping.Rmd’ ‘expire_user_project_rights.Rmd’
#12 21.01 
#12 21.01 Error: Vignette re-building failed.
#12 21.01 Execution halted
```