### PR TITLE
Add batch_size param to dbx calls in sync_table

### DIFF
--- a/R/write_data.R
+++ b/R/write_data.R
@@ -249,7 +249,8 @@ sync_table_2 <- function(
       conn = conn,
       table = table_name,
       records = update_records,
-      where_cols = target_pk
+      where_cols = target_pk,
+      batch_size = 100
     )
     update_n <- nrow(update_records)
   } else {
@@ -266,7 +267,8 @@ sync_table_2 <- function(
     dbx::dbxDelete(
       conn = conn,
       table = table_name,
-      where = delete_records
+      where = delete_records,
+      batch_size = 100
     )
     delete_n <- nrow(delete_records)
   } else {

--- a/R/write_data.R
+++ b/R/write_data.R
@@ -151,7 +151,8 @@ sync_table <- function(
       conn = conn,
       table = table_name,
       records = data_diff_output$update_records,
-      where_cols = primary_key
+      where_cols = primary_key,
+      batch_size = 100
     )
     update_n <- nrow(data_diff_output$update_records)
   }
@@ -160,7 +161,8 @@ sync_table <- function(
     dbx::dbxDelete(
       conn = conn,
       table = table_name,
-      where = data_diff_output$delete_records
+      where = data_diff_output$delete_records,
+      batch_size = 100
     )
     delete_n <- nrow(data_diff_output$delete_records)
   }


### PR DESCRIPTION
Prevents possible error: Expression tree is too large (maximum depth 1000)

I ran into this issue trying to delete ~2000 rows from a local database.