### PR TITLE
Remove select packages from tlmgr_install and add quarto

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN R -e "install.packages(c( \
   'dotenv', \
   'here', \
   'janitor', \
+  'quarto', \
   'rjson', \
   'sendmailR', \
   'sqldf', \
@@ -26,18 +27,31 @@ RUN R -e "install.packages(c( \
 
 RUN R -e "devtools::install_github('allanvc/mRpostman')"
 RUN R -e "tinytex::tlmgr_install(c(\
-  'amscls', 'amsmath', 'booktabs', \
+  'amscls', 'amsmath', \
+  'bookmark', \
+  'booktabs', \
   'caption','colortbl', 'dvips', \
-  'ec', 'environ', 'epstopdf-pkg', 'etoolbox', 'euenc', \
-  'fancyvrb', 'float', 'fontspec', 'framed', 'geometry', \
+  'ec', 'environ', 'epstopdf-pkg', \
+  'etoolbox', 'euenc', \
+  'fancyvrb', 'float', 'fontspec', \
+  'framed', 'geometry', \
   'gsftopk', 'helvetic', \
   'hyperref', 'iftex', \
+  'koma-script', \
   'latexmk', \
   'makecell', 'mathspec', \
-  'mdwtools', 'multirow', 'natbib', 'oberdiek', 'pdflscape', \
+  'mdwtools', 'multirow', \
+  'natbib', 'oberdiek', \
+  'pdfcol', \
+  'pdflscape', \
+  'pgf', \
   'tabu', \
-  'threeparttable', 'threeparttablex', 'times', 'tipa', 'titling', \
-  'trimspaces', 'ulem', 'upquote', \
+  'tcolorbox', \
+  'threeparttable', 'threeparttablex', \
+  'times', 'tipa', 'titling', \
+  'trimspaces', 'ulem', \
+  'unicode-math', \
+  'upquote', \
   'varwidth', 'wrapfig', 'xcolor', \
   'xunicode', 'zapfding' \
 ))"

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,20 +26,19 @@ RUN R -e "install.packages(c( \
 
 RUN R -e "devtools::install_github('allanvc/mRpostman')"
 RUN R -e "tinytex::tlmgr_install(c(\
-  'amscls', 'amsfonts', 'amsmath', 'babel', 'bibtex', 'booktabs', \
-  'caption', 'cm', 'colortbl', 'dehyph', 'dvipdfmx', 'dvips', \
-  'ec', 'environ', 'epstopdf-pkg', 'etex', 'etoolbox', 'euenc', \
-  'fancyvrb', 'float', 'fontspec', 'framed', 'geometry', 'glyphlist', \
-  'graphics', 'graphics-cfg', 'graphics-def', 'gsftopk', 'helvetic', \
-  'hyperref', 'hyphen-base', 'ifluatex', 'iftex', 'ifxetex', 'inconsolata', \
-  'knuth-lib', 'kpathsea', 'l3kernel', 'l3packages', 'latex', 'latex-bin', \
-  'latex-fonts', 'latexconfig', 'latexmk', 'lm', 'lualibs', 'luaotfload', \
-  'luatex', 'makecell', 'makeindex', 'mathspec', 'metafont', 'mfware', \
-  'mdwtools', 'multirow', 'natbib', 'oberdiek', 'pdflscape', 'pdftex', 'plain', \
-  'scheme-infraonly', 'tabu', 'tetex', 'tex', 'tex-ini-files', 'texlive.infra', \
+  'amscls', 'amsmath', 'booktabs', \
+  'caption','colortbl', 'dvips', \
+  'ec', 'environ', 'epstopdf-pkg', 'etoolbox', 'euenc', \
+  'fancyvrb', 'float', 'fontspec', 'framed', 'geometry', \
+  'gsftopk', 'helvetic', \
+  'hyperref', 'iftex', \
+  'latexmk', \
+  'makecell', 'mathspec', \
+  'mdwtools', 'multirow', 'natbib', 'oberdiek', 'pdflscape', \
+  'tabu', \
   'threeparttable', 'threeparttablex', 'times', 'tipa', 'titling', \
-  'tools', 'trimspaces', 'ulem', 'unicode-data', 'upquote', 'url', \
-  'varwidth', 'wrapfig', 'xcolor', 'xetex', 'xetexconfig', 'xkeyval', \
+  'trimspaces', 'ulem', 'upquote', \
+  'varwidth', 'wrapfig', 'xcolor', \
   'xunicode', 'zapfding' \
 ))"
 


### PR DESCRIPTION
Remove packages that are already installed.
Remove packages that can't be installed: tetex, ifxetex, and ifluatex.
Add Quarto.
Add packages tlmgr packages quarto needs for PDF output