### PR TITLE
Add to credential scraping

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -69,6 +69,6 @@ Suggests:
     tidyverse
 VignetteBuilder: knitr
 Config/testthat/edition: 3
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 Depends: 
     R (>= 3.5.0)

--- a/R/credential_management.R
+++ b/R/credential_management.R
@@ -22,7 +22,7 @@ scrape_user_api_tokens <- function(conn, username_to_scrape = Sys.info()[["user"
   # collect super API token if one exists
   super_credentials <- dplyr::tbl(conn, "redcap_user_information") %>%
     dplyr::filter(.data$username == username_to_scrape) %>%
-    dplyr::select(.data$username, .data$api_token) %>%
+    dplyr::select("username", "api_token") %>%
     dplyr::collect() %>%
     dplyr::mutate(project_id = 0) %>%
     dplyr::filter(!is.na(.data$api_token)) %>%
@@ -32,16 +32,16 @@ scrape_user_api_tokens <- function(conn, username_to_scrape = Sys.info()[["user"
     dplyr::filter(.data$username == username_to_scrape) %>%
     dplyr::filter(!is.na(.data$api_token)) %>%
     dplyr::select(
-      .data$project_id,
-      .data$username,
-      .data$api_token
+      "project_id",
+      "username",
+      "api_token"
     ) %>%
     # add project information
     dplyr::left_join(
       dplyr::tbl(conn, "redcap_projects") %>%
         dplyr::select(
-          .data$project_id,
-          .data$app_title
+          "project_id",
+          "app_title"
         ),
       by = "project_id"
     ) %>%
@@ -49,8 +49,8 @@ scrape_user_api_tokens <- function(conn, username_to_scrape = Sys.info()[["user"
     # bind_rows used over rbind to avoid need to align column order
     dplyr::bind_rows(super_credentials) %>%
     dplyr::rename(
-      project_display_name = .data$app_title,
-      token = .data$api_token # rename for compatibility with REDCapR credential objects
+      project_display_name = "app_title",
+      token = "api_token" # rename for compatibility with REDCapR credential objects
     )
 
   return(credentials)

--- a/vignettes/credential-scraping.Rmd
+++ b/vignettes/credential-scraping.Rmd
@@ -115,6 +115,61 @@ dbDisconnect(file_conn)
 dbDisconnect(source_conn)
 ```
 
+### Scraping one user's API tokens
+
+Scraping one user's API tokens and putting them in a new, local sqlite DB for use.
+
+```{r, eval = FALSE}
+library(redcapcustodian)
+library(DBI)
+library(tidyverse)
+library(dotenv)
+
+# get the username provided on the command line
+args <- commandArgs(trailingOnly = TRUE)
+username <- args
+
+# Creates the credentials file if one does not exists.
+# Otherwise it deletes the credentials file
+credentials_db_path <- here::here(paste0("credentials-", username, ".db"))
+if (fs::file_exists(credentials_db_path)) fs::file_delete(credentials_db_path)
+file_conn <- DBI::dbConnect(RSQLite::SQLite(), credentials_db_path)
+
+# SQLite friendly schema
+credentials_sql <- "CREATE TABLE IF NOT EXISTS `credentials` (
+  `redcap_uri` TEXT NOT NULL,
+  `server_short_name` varchar(128) NOT NULL,
+  `username` varchar(191) NOT NULL,
+  `project_id` int(10) NOT NULL,
+  `project_display_name` TEXT NOT NULL,
+  `project_short_name` varchar(128) DEFAULT NULL,
+  `token` varchar(64) NOT NULL,
+  `comment` varchar(256) DEFAULT NULL
+);
+"
+
+dbExecute(file_conn, credentials_sql)
+
+# Connect to the REDCap database specified in the environment
+# loaded by the dotenv library
+source_conn <- connect_to_redcap_db()
+source_credentials <- scrape_user_api_tokens(
+  conn = source_conn,
+  username_to_scrape = username
+)
+
+# alter credentials to match local schema
+source_credentials_upload <- source_credentials %>%
+  mutate(
+    redcap_uri = Sys.getenv("URI"),
+    server_short_name = tolower(Sys.getenv("INSTANCE"))
+  )
+
+dbAppendTable(file_conn, "credentials", source_credentials_upload)
+
+dbDisconnect(file_conn)
+dbDisconnect(source_conn)
+```
 ### Creating API tokens for all local projects
 
 ```{r, eval = FALSE}

--- a/vignettes/credential-scraping.Rmd
+++ b/vignettes/credential-scraping.Rmd
@@ -117,7 +117,13 @@ dbDisconnect(source_conn)
 
 ### Scraping one user's API tokens
 
-Scraping one user's API tokens and putting them in a new, local sqlite DB for use.
+Scraping one user's API tokens and putting them in a new, local sqlite DB for use. 
+
+You must provide the username in the API_USER environment variable or on the command line. To specify it on the command line via `Rscript` and specify a REDCap username. e.g.
+
+```sh
+Rscript scrape_one_user.R jane_doe
+```
 
 ```{r, eval = FALSE}
 library(redcapcustodian)
@@ -125,9 +131,21 @@ library(DBI)
 library(tidyverse)
 library(dotenv)
 
-# get the username provided on the command line
+# Get the username provided on the command line if one is provided. 
+# Otherwise, get the username form the environment.
+# Otherwise, exit.
 args <- commandArgs(trailingOnly = TRUE)
-username <- args
+if (length(args) > 0) {
+  # Use the command line argument
+  username <- args
+} else if (Sys.getenv("API_USER") != "") {
+  # Use the environment variable
+  username <- Sys.getenv("API_USER")
+} else {
+  # Exit
+  warning("Please provide an username that whose API tokens you want to read either on the command line or via the API_USER environment variable. No action taken.")
+  quit()
+}
 
 # Creates the credentials file if one does not exists.
 # Otherwise it deletes the credentials file

--- a/vignettes/credential-scraping.Rmd
+++ b/vignettes/credential-scraping.Rmd
@@ -143,7 +143,7 @@ if (length(args) > 0) {
   username <- Sys.getenv("API_USER")
 } else {
   # Exit
-  warning("Please provide an username that whose API tokens you want to read either on the command line or via the API_USER environment variable. No action taken.")
+  warning("Please provide a username that whose API tokens you want to read either on the command line or via the API_USER environment variable. No action taken.")
   quit()
 }
 


### PR DESCRIPTION
I did this to make it easier to make a database API Tokens for a REDCap service account. The GRACE project inspired this. This PR introduces the concept of a new env var, API_USER, which is the account username whose tokens should be read. This is ideal for a multi-project study like GRACE.

* Update scrape_user_api_tokens() to tidyselect 1.2 standards - Philip Chase
* Add 'Scraping one user's API tokens' section to vignettes/credential-scraping.Rmd - Philip Chase
