### PR TITLE
Implement hacky fix for tlmgr 2023 being unable to install packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
-FROM --platform=linux/amd64 rocker/verse:4.3.2
+FROM --platform=linux/amd64 rocker/verse:4.3.3
 
 WORKDIR /home/rocker
 
 RUN apt update -y && apt install -y libmariadb-dev libmariadb-dev-compat
 RUN apt install -y --no-install-recommends libxt6
+
+# returns an error but tlmgr is updated to 2024 regardless
+RUN wget ${CTAN_REPO}/update-tlmgr-latest.sh && bash update-tlmgr-latest.sh; exit 0
 
 # install necessary libraries
 RUN R -e "install.packages(c( \

--- a/R/logging.R
+++ b/R/logging.R
@@ -689,7 +689,7 @@ send_email <-
       email_to <- unlist(strsplit(email_to, " "))
     }
 
-    email_content <- list(email_body)
+    email_content <- email_body
 
     if (!is.null(file_name)) {
       output_dir <- tempdir()


### PR DESCRIPTION
Patches inability to render `qmd` reports due to outdated `tlmgr` (2023) being unable to pull from TeXlive