### PR TITLE
Remove log and output folders

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: ghcr.io/ctsit/rstudio-ci:4.3.3
+      image: ghcr.io/ctsit/rstudio-ci:latest
 
     env:
       CI: "TRUE"

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -60,7 +60,8 @@ Imports:
     tidyr,
     vctrs,
     jsonlite,
-    openxlsx
+    openxlsx,
+    quarto
 Suggests:
     RSQLite,
     digest,

--- a/R/reporting.R
+++ b/R/reporting.R
@@ -35,7 +35,7 @@ render_report <- function(script_path) {
   script_path_without_extension <- tools::file_path_sans_ext(script_path)
   base_script_name <- basename(script_path_without_extension)
   run_time <- format(redcapcustodian::get_script_run_time(), "%Y-%m-%d_%H%M%S")
-  logfile <- here::here("report", "log", paste0(base_script_name, "_", run_time, ".txt"))
+  logfile <- file.path(tempdir(), paste0(base_script_name, "_", run_time, ".txt"))
 
   result <- tryCatch({
     capture.output(quarto::quarto_render(script_path), file = logfile)
@@ -55,15 +55,9 @@ render_report <- function(script_path) {
     if (file.exists(default_filename)) {
       file_extension <- tools::file_ext(default_filename)
 
-      report_name <- paste0(
-        base_script_name,
-        "_",
-        run_time,
-        ".",
-        file_extension
-      )
+      report_name <- paste0(base_script_name, "_", run_time, ".", file_extension)
 
-      report_filepath <- here::here("report", "output", report_name)
+      report_filepath <- file.path("report", report_name)
 
       file.rename(default_filename, report_filepath)
 

--- a/R/reporting.R
+++ b/R/reporting.R
@@ -38,7 +38,7 @@ render_report <- function(script_path) {
   logfile <- file.path(tempdir(), paste0(base_script_name, "_", run_time, ".txt"))
 
   result <- tryCatch({
-    capture.output(quarto::quarto_render(script_path), file = logfile)
+    utils::capture.output(quarto::quarto_render(script_path), file = logfile)
     list(success = TRUE)
   }, error = function(e) {
     list(success = FALSE, logfile = logfile, error = e$message)

--- a/report/log/.gitignore
+++ b/report/log/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/report/output/.gitignore
+++ b/report/output/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/study_template/report/log/.gitignore
+++ b/study_template/report/log/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/study_template/report/output/.gitignore
+++ b/study_template/report/output/.gitignore
@@ -1,4 +1,0 @@
-*.csv
-*.xlsx
-*.html
-*.pdf


### PR DESCRIPTION
This PR:

1. Removes `report/log` and writes the logfile to a temp folder instead.
2. Removes `report/output`.
