### PR TITLE
Update container and refactor CI

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -1,4 +1,4 @@
-name: Run tests 
+name: Run tests
 
 on:
   push:
@@ -7,53 +7,66 @@ on:
     branches: [ develop ]
 
 jobs:
-  test:
+  build:
     runs-on: ubuntu-latest
-
-    container:
-      image: ghcr.io/ctsit/rstudio-ci:latest
-
-    env:
-      CI: "TRUE"
-      R_LIBS_USER: /github/home/R/x86_64-pc-linux-gnu-library/4.4
-      R_LIB_FOR_PAK: /usr/local/lib/R/site-library
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image: ${{ steps.tag.outputs.image }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      # Create directories for R libraries if not already present
-      - name: Create R Library Paths
+      - name: Compute image tag from Dockerfile hash
+        id: tag
         run: |
-          mkdir -p /github/home/R/x86_64-pc-linux-gnu-library/4.4
-          mkdir -p renv/library
+          hash=$(sha256sum Dockerfile | cut -c1-16)
+          echo "image=ghcr.io/ctsit/redcapcustodian:${hash}" >> $GITHUB_OUTPUT
 
-      # Restore cache for R dependencies
-      - name: Restore R Dependencies Cache
-        uses: actions/cache@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
         with:
-          path: |
-            /github/home/R/x86_64-pc-linux-gnu-library/4.4
-            renv/library
-          key: ${{ runner.os }}-r-libs-${{ hashFiles('DESCRIPTION') }}
-          restore-keys: |
-            ${{ runner.os }}-r-libs-
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Install R dependencies
-      - name: Install R Dependencies
-        uses: r-lib/actions/setup-r-dependencies@v2
+      - name: Check if image already exists
+        id: check
+        run: |
+          if docker manifest inspect ${{ steps.tag.outputs.image }} > /dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Set up Docker Buildx
+        if: steps.check.outputs.exists == 'false'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        if: steps.check.outputs.exists == 'false'
+        uses: docker/build-push-action@v6
         with:
-          cache: false
+          context: .
+          push: true
+          tags: ${{ steps.tag.outputs.image }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
-      # Run tests
-      - name: Run Tests
-        run: devtools::test(stop_on_failure = TRUE)
-        shell: Rscript {0}
+  test:
+    needs: build
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ needs.build.outputs.image }}
+    env:
+      CI: "TRUE"
 
-      # Save R dependencies to cache
-      - name: Save R Dependencies Cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            /github/home/R/x86_64-pc-linux-gnu-library/4.4
-            renv/library
-          key: ${{ runner.os }}-r-libs-${{ hashFiles('DESCRIPTION') }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install test-only dependencies
+        run: R -e "install.packages(c('RSQLite', 'duckdb'))"
+
+      - name: Run tests
+        run: R -e "devtools::test(stop_on_failure = TRUE)"

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -70,3 +70,33 @@ jobs:
 
       - name: Run tests
         run: R -e "devtools::test(stop_on_failure = TRUE)"
+
+  tag:
+    needs: [build, test]
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read VERSION
+        id: version
+        run: echo "version=$(cat VERSION)" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Promote image to latest and version tags
+        run: |
+          docker buildx imagetools create \
+            --tag ghcr.io/ctsit/redcapcustodian:latest \
+            --tag ghcr.io/ctsit/redcapcustodian:${{ steps.version.outputs.version }} \
+            ${{ needs.build.outputs.image }}

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -2,7 +2,7 @@ name: Run tests
 
 on:
   push:
-    branches: [ develop ]
+    branches: [ develop, master ]
   pull_request:
     branches: [ develop ]
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,113 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this project is
+
+`redcapcustodian` is an R package (v1.28.x) that provides a framework for automating ETL work against REDCap systems and their underlying MySQL databases. It ships three things together:
+
+1. **R package** — functions for credential management, DB connections, data diffing/syncing, logging, and email alerting.
+2. **Docker image** — built on `rocker/verse:4.4.1`, packages the R library for automated deployment.
+3. **`study_template/`** — a starting point for a downstream repository that builds on this image to implement study-specific ETL jobs.
+
+## Commands
+
+### Run tests
+```r
+devtools::test()                          # all tests
+devtools::test(filter = "logging")        # single test file (matches test-logging.R)
+testthat::test_file("tests/testthat/test-logging.R")
+```
+
+### Build and check the package
+```r
+devtools::check()                         # R CMD check
+devtools::document()                      # regenerate NAMESPACE and man/ from roxygen2
+devtools::build()                         # build tarball
+```
+
+### Build the Docker image
+```sh
+./build.sh                               # builds and tags redcapcustodian:latest and redcapcustodian:<VERSION>
+```
+
+## Architecture
+
+### Package-scoped state (`redcapcustodian.env`)
+
+The package maintains a private environment (`redcapcustodian.env` in `R/logging.R`) that acts as global state across ETL scripts. The canonical way to initialize it is `init_etl()` (`R/utils.R`), which calls:
+- `set_project_name()` / `set_project_instance()` — read from env vars `PROJECT` / `INSTANCE`
+- `set_script_name()` — auto-detected from command args or RStudio context
+- `set_script_run_time()` — captured at job start
+- `init_log_con()` — connects to the log DB and stores the connection
+
+Use `get_package_scope_var()` / `set_package_scope_var()` for arbitrary package-scoped values.
+
+### Database connection pattern
+
+DB connections follow a `<PREFIX>_DB_*` environment variable convention:
+- `REDCAP_DB_*` — the REDCap MySQL database (direct schema access)
+- `LOG_DB_*` — the logging database (writes to `rcc_job_log` and `etl_log`)
+- `ETL_DB_*` — an optional ETL target database
+- `CREDENTIALS_DB` — path to a SQLite file used by `get_redcap_credentials()`
+
+`connect_to_db(drv, prefix)` is the underlying generic; `connect_to_redcap_db()` and `connect_to_log_db()` are convenience wrappers.
+
+Tests use **DuckDB** (`duckdb::duckdb()`) as an in-memory substitute for the log DB — pass it to `init_etl(log_db_drv = duckdb::duckdb())`.
+
+### Data sync pattern (`dataset_diff` → `sync_table`)
+
+The core ETL pattern in `R/dataset_diff.R` and `R/write_data.R`:
+
+1. `dataset_diff(source, source_pk, target, target_pk)` computes `insert_records`, `update_records`, `delete_records`.
+2. `sync_table(conn, table_name, primary_key, data_diff_output)` writes those diffs back via `DBI::dbAppendTable` (inserts), `dbx::dbxUpdate` (updates), `dbx::dbxDelete` (deletes). All three flags default off except `update = TRUE`.
+3. `sync_table_2()` is a combined wrapper that calls `dataset_diff` internally and returns both the diff and the row counts.
+
+### Logging
+
+Two log tables (schemas in `inst/schema/`):
+- `rcc_job_log` — one row per job run; columns include `level` (SUCCESS/DEBUG/ERROR), `job_summary_data`, `job_duration`.
+- `etl_log` — one row per record written; used by `write_info_log_entry()` / `write_error_log_entry()`.
+
+Public API: `log_job_success()`, `log_job_failure()`, `log_job_debug()` — all require `init_etl()` to have been called first.
+
+### Email
+
+`send_email()` (`R/logging.R`) wraps `sendmailR`. Configuration comes from env vars: `SMTP_SERVER`, `EMAIL_FROM`, `EMAIL_TO`, `EMAIL_CC`. Optional attachments accept CSV, XLSX, ZIP, or TXT.
+
+### Credential management
+
+`get_redcap_credentials()` (`R/get_redcap_credentials.R`) queries a SQLite `credentials` table from the path in `CREDENTIALS_DB`. `scrape_user_api_tokens()` (`R/credential_management.R`) reads tokens directly from the REDCap MySQL database for a given username.
+
+### REDCap-specific helpers
+
+- `connect_to_redcap_db()` / `get_redcap_db_connection()` — manage the package-scoped MySQL connection to REDCap.
+- `sync_metadata()` (`R/multi_instance.R`) — copies a data dictionary between REDCap projects via the API.
+- `expire_user_project_rights()` (`R/user_rights.R`) — bulk-expires user rights directly in the REDCap DB.
+- `get_project_life_cycle()` (`R/project_life_cycle.R`) — reconstructs project history from REDCap log event tables.
+
+### Testing conventions
+
+- Tests use in-memory SQLite or DuckDB; never a live DB.
+- `inst/testdata/` holds CSV + SQL schema pairs (`redcap_projects`, `redcap_user_information`). Load them with `create_test_table(conn, "redcap_projects")` or `create_test_tables(conn)` (`R/devtools.R`).
+- `tests/testthat/helper.R` defines shared helpers; `setup.R` loads common libraries.
+- `disable_non_interactive_quit()` must be called in tests that exercise code paths that would otherwise call `q()` on failure.
+- `convert_schema_to_sqlite()` translates MySQL schemas to SQLite for in-memory testing (uses `inst/to_sqlite.pl`).
+
+### Environment / configuration
+
+Scripts use `dotenv::load_dot_env()` to load `.env` files. `study_template/example.env` documents all supported env vars. `TIME_ZONE` is used throughout for consistent datetime handling via `lubridate::with_tz()`.
+
+### ETL script lifecycle
+
+Each deployed ETL script follows this pattern:
+```r
+library(redcapcustodian)
+library(dotenv)
+dotenv::load_dot_env()
+init_etl("script_name.R")   # sets up logging, sets script_run_time
+# ... do work ...
+log_job_success(rjson::toJSON(summary_list))
+```
+
+`etl/run_etl.R` is a generic wrapper that runs any Rscript via `callr::rscript()` and emails the log on failure.

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,4 +82,4 @@ RUN rm -rf .Rhistory
 RUN rm -rf Dockerfile
 
 # Note where we are, what is there, and what's in the package dir
-CMD pwd && ls -AlhF ./
+CMD ["sh", "-c", "pwd && ls -AlhF ./"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rocker/verse:4.4.1
+FROM rocker/verse:4.5.3
 
 WORKDIR /home/rocker
 
@@ -31,7 +31,7 @@ RUN R -e "install.packages(c( \
   'getip' \
 ))"
 
-RUN R -e "devtools::install_github('allanvc/mRpostman')"
+RUN R -e "pak::pak('allanvc/mRpostman')"
 RUN R -e "tinytex::tlmgr_install(c(\
   'amscls', 'amsmath', \
   'bookmark', \

--- a/build.sh
+++ b/build.sh
@@ -23,4 +23,4 @@ shift $((OPTIND -1))
 
 shared_image=redcapcustodian
 echo "Building $shared_image image"
-docker build -t $shared_image . && docker tag $shared_image:latest $shared_image:`cat VERSION` && docker image ls $shared_image | head -n 5
+docker build --platform=linux/amd64 -t $shared_image . && docker tag $shared_image:latest $shared_image:`cat VERSION` && docker image ls $shared_image | head -n 5

--- a/study_template/build.sh
+++ b/study_template/build.sh
@@ -71,5 +71,5 @@ site_image=${image_name}
 echo "Building $site_image"
 old_pwd=$(pwd)
 cd $sitepath
-docker build -t $site_image . && docker tag $site_image:latest $site_image:`cat VERSION` && docker image ls $site_image | head -n 5
+docker build --platform=linux/amd64 -t $site_image . && docker tag $site_image:latest $site_image:`cat VERSION` && docker image ls $site_image | head -n 5
 cd $old_pwd


### PR DESCRIPTION
## Summary

- Updates base image from `rocker/verse:4.4.1` to `rocker/verse:4.5.3` and moves `--platform=linux/amd64` flag from Dockerfile to `build.sh`
- Fixes Docker lint warning by converting `CMD` from shell form to JSON exec form
- Rewrites CI to build and cache the `redcapcustodian` image in GHCR (keyed on Dockerfile hash), run tests inside it, and only promote `latest` and version tags after tests pass
- Adds `CLAUDE.md` with codebase guidance for Claude Code

## Test plan

- [x] Confirm the `build` job pushes a hash-tagged image to `ghcr.io/ctsit/redcapcustodian` on first run
- [x] Confirm the `build` job skips the build on a second run with no Dockerfile changes
- [x] Confirm the `test` job runs inside the built image and passes
- [x] Confirm the `tag` job promotes `latest` and the version tag only after tests pass
- [x] Set the GHCR package visibility to public and confirm downstream repos can pull without authentication
- [x] Confirm `docker build` locally produces no lint warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)